### PR TITLE
Update golangci lint and go version to current version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version: '~1.24'
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.61
+          version: v2.1.2


### PR DESCRIPTION
This at least fixes the jasonschema complaints.

We should decide if we want to run the linter at all - i.e. if we will fix the issues it reports current - or not.