### PR TITLE
Linting cleanup

### DIFF
--- a/cmd/parserapp/main.go
+++ b/cmd/parserapp/main.go
@@ -94,7 +94,7 @@ func main() {
 	devContainerSpec := &parsing.DevContainerSpec{}
 	// converts non-conformant JSON to conformant JSON, e.g.,
 	//  strips comments, fixes trailing commas. For more info see hujson package.
-	data, err := hujson.Standardize([]byte(rawData))
+	data, err := hujson.Standardize(rawData)
 	if err != nil {
 		log.Error(err, "could not standardize json")
 		os.Exit(-1)

--- a/cmd/parserapp/main.go
+++ b/cmd/parserapp/main.go
@@ -42,7 +42,8 @@ func logDir(ctx context.Context, dir string) {
 	}
 }
 
-var LabelDefinitionMapKey = devcontainerv1alpha1.SchemeBuilder.GroupVersion.Version + "." + devcontainerv1alpha1.SchemeBuilder.GroupVersion.Group + "/definitionID"
+var LabelDefinitionMapKey = devcontainerv1alpha1.SchemeBuilder.GroupVersion.Version +
+	"." + devcontainerv1alpha1.SchemeBuilder.GroupVersion.Group + "/definitionID"
 
 const DEFINITION_ENV_NAME = "DEFINITION_ENV_NAME"
 const DEFINITION_ENV_ID = "DEFINITION_ENV_ID"
@@ -91,7 +92,8 @@ func main() {
 		return
 	}
 	devContainerSpec := &parsing.DevContainerSpec{}
-	// converts non-conformant JSON to conformant JSON, e.g., strips comments, fixes trailing commas. For mroe info see hujson package.
+	// converts non-conformant JSON to conformant JSON, e.g.,
+	//  strips comments, fixes trailing commas. For mroe info see hujson package.
 	data, err := hujson.Standardize([]byte(rawData))
 	if err != nil {
 		log.Error(err, "could not standardize json")

--- a/cmd/parserapp/main.go
+++ b/cmd/parserapp/main.go
@@ -93,7 +93,7 @@ func main() {
 	}
 	devContainerSpec := &parsing.DevContainerSpec{}
 	// converts non-conformant JSON to conformant JSON, e.g.,
-	//  strips comments, fixes trailing commas. For mroe info see hujson package.
+	//  strips comments, fixes trailing commas. For more info see hujson package.
 	data, err := hujson.Standardize([]byte(rawData))
 	if err != nil {
 		log.Error(err, "could not standardize json")

--- a/cmd/parserapp/main.go
+++ b/cmd/parserapp/main.go
@@ -155,7 +155,7 @@ func main() {
 
 	var ports []corev1.ContainerPort
 	// len > 0 probably covers the nil check, remove in future
-	if devContainerSpec.Ports != nil && len(devContainerSpec.Ports) > 0 {
+	if len(devContainerSpec.Ports) > 0 {
 		ports = make([]corev1.ContainerPort, 0)
 		for port, meta := range devContainerSpec.Ports {
 			p, err := strconv.ParseInt(port, 10, 32)

--- a/internal/controller/definition_controller.go
+++ b/internal/controller/definition_controller.go
@@ -668,7 +668,7 @@ func (r *DefinitionReconciler) gitCloneContainer(inst *devcontainerv1alpha1.Defi
 		// TODO (juf): make configurable
 		Image:           GIT_IMAGE_NAME,
 		ImagePullPolicy: corev1.PullAlways,
-		//Command:         []string{"/bin/sh", "-c", "sleep infinity"},
+		// Command:         []string{"/bin/sh", "-c", "sleep infinity"},
 		Env: []corev1.EnvVar{
 			{
 				Name:  "REPO_URL",

--- a/internal/controller/definition_controller.go
+++ b/internal/controller/definition_controller.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -598,7 +598,7 @@ func (r *DefinitionReconciler) pvcForGitRepo(inst *devcontainerv1alpha1.Definiti
 		},
 	}
 	if inst.Spec.StorageClassName != "" {
-		pvc.Spec.StorageClassName = pointer.String(inst.Spec.StorageClassName)
+		pvc.Spec.StorageClassName = ptr.To[string](inst.Spec.StorageClassName)
 	}
 	if err := ctrl.SetControllerReference(inst, pvc, r.Scheme); err != nil {
 		return nil, err
@@ -641,7 +641,7 @@ func (r *DefinitionReconciler) setupPod(inst *devcontainerv1alpha1.Definition, s
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  src.Spec.GitSecret,
-					DefaultMode: pointer.Int32(0600),
+					DefaultMode: ptr.To[int32](0600),
 				},
 			},
 		})

--- a/internal/controller/definition_controller.go
+++ b/internal/controller/definition_controller.go
@@ -93,7 +93,7 @@ func (r *DefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// Finalizer Section
 		finalizerName, executor := DefinitionFinalizerForRelatedWorkspaces()
 		// See documentation of the field, it's enlightning
-		if instance.ObjectMeta.DeletionTimestamp.IsZero() {
+		if instance.DeletionTimestamp.IsZero() {
 			// TODO(juf): AddFinalizer is probably idempotent and tells us if it's a no-op,
 			// so we probably could and should remove the Contains check. Only if it makes sense though.
 			if on == "yes" {
@@ -546,10 +546,10 @@ func (r *DefinitionReconciler) ensureResource(ctx context.Context, obj client.Ob
 	key := client.ObjectKeyFromObject(obj)
 
 	// Try to get the resource
-	if err := r.Client.Get(ctx, key, obj); err != nil {
+	if err := r.Get(ctx, key, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Resource does not exist, create it
-			if err := r.Client.Create(ctx, obj); err != nil {
+			if err := r.Create(ctx, obj); err != nil {
 				return fmt.Errorf("failed to create resource: %w", err)
 			}
 			return nil

--- a/internal/controller/definition_controller.go
+++ b/internal/controller/definition_controller.go
@@ -82,7 +82,7 @@ func (r *DefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		log.Error(err, "Failed to get instance")
 		return ctrl.Result{}, err
 	} // Let's just set the status as Unknown when no status is available
-	if instance.Status.Conditions == nil || len(instance.Status.Conditions) == 0 {
+	if len(instance.Status.Conditions) == 0 {
 		if err := r.updateStatusMany(ctx, req.NamespacedName, instance, devcontainerv1alpha1.InitialConditionsDefinition()); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -136,6 +136,10 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		"metadata.ownerReferences.kind": instance.Kind,
 		"metadata.ownerReferences.name": instance.Name,
 	})
+	if err != nil {
+		log.Error(err, "Failed to list owned deployments")
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
 	// If size equals 0, we have a problem,
 	// if size equals 1 we are already in a healthy state,
 	// if size is greater than 1 we need to clean up

--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -238,7 +238,7 @@ func (r *WorkspaceReconciler) ensurePVC(ctx context.Context, inst *devcontainerv
 		},
 	}
 	if inst.Spec.StorageClassName != "" {
-		pvc.Spec.StorageClassName = pointer.String(inst.Spec.StorageClassName)
+		pvc.Spec.StorageClassName = ptr.To[string](inst.Spec.StorageClassName)
 	}
 	if err := ctrl.SetControllerReference(inst, pvc, r.Scheme); err != nil {
 		return nil, err
@@ -257,7 +257,7 @@ func (r *WorkspaceReconciler) injectSecret(spec *devcontainerv1alpha1.SourceSpec
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  spec.GitSecret,
-					DefaultMode: pointer.Int32(0600),
+					DefaultMode: ptr.To[int32](0600),
 				},
 			},
 		})

--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -451,10 +451,10 @@ func (r *WorkspaceReconciler) ensureResource(ctx context.Context, obj client.Obj
 	key := client.ObjectKeyFromObject(obj)
 
 	// Try to get the resource
-	if err := r.Client.Get(ctx, key, obj); err != nil {
+	if err := r.Get(ctx, key, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Resource does not exist, create it
-			if err := r.Client.Create(ctx, obj); err != nil {
+			if err := r.Create(ctx, obj); err != nil {
 				return fmt.Errorf("failed to create resource: %w", err)
 			}
 			return nil

--- a/internal/parsing/devcontainerspec.go
+++ b/internal/parsing/devcontainerspec.go
@@ -34,7 +34,7 @@ func (cmd Cmd) MarshalJSON() ([]byte, error) {
 	if cmd.Array != nil {
 		return json.Marshal(cmd.Array)
 	}
-	return nil, errors.New("Neither string nor array of cmd are defined, cannot marshal json")
+	return nil, errors.New("neither string nor array of cmd are defined, cannot marshal json")
 }
 
 type DevContainerSpec struct {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -93,27 +93,27 @@ var _ = Describe("Manager", Ordered, func() {
 			cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
 			controllerLogs, err := utils.Run(cmd)
 			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, fmt.Sprintf("Controller logs:\n %s", controllerLogs))
+				_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n %s", controllerLogs)
 			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, fmt.Sprintf("Failed to get Controller logs: %s", err))
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Controller logs: %s", err)
 			}
 
 			By("Fetching Kubernetes events")
 			cmd = exec.Command("kubectl", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
 			eventsOutput, err := utils.Run(cmd)
 			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, fmt.Sprintf("Kubernetes events:\n%s", eventsOutput))
+				_, _ = fmt.Fprintf(GinkgoWriter, "Kubernetes events:\n%s", eventsOutput)
 			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, fmt.Sprintf("Failed to get Kubernetes events: %s", err))
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Kubernetes events: %s", err)
 			}
 
 			By("Fetching curl-metrics logs")
 			cmd = exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
 			metricsOutput, err := utils.Run(cmd)
 			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, fmt.Sprintf("Metrics logs:\n %s", metricsOutput))
+				_, _ = fmt.Fprintf(GinkgoWriter, "Metrics logs:\n %s", metricsOutput)
 			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, fmt.Sprintf("Failed to get curl-metrics logs: %s", err))
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get curl-metrics logs: %s", err)
 			}
 
 			By("Fetching controller manager pod description")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -278,7 +278,7 @@ func serviceAccountToken() (string, error) {
 
 		// Parse the JSON output to extract the token
 		var token tokenRequest
-		err = json.Unmarshal([]byte(output), &token)
+		err = json.Unmarshal(output, &token)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		out = token.Status.Token

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -92,7 +92,7 @@ func IsPrometheusCRDsInstalled() bool {
 	if err != nil {
 		return false
 	}
-	crdList := GetNonEmptyLines(string(output))
+	crdList := GetNonEmptyLines(output)
 	for _, crd := range prometheusCRDs {
 		for _, line := range crdList {
 			if strings.Contains(line, crd) {
@@ -153,7 +153,7 @@ func IsCertManagerCRDsInstalled() bool {
 	}
 
 	// Check if any of the Cert Manager CRDs are present
-	crdList := GetNonEmptyLines(string(output))
+	crdList := GetNonEmptyLines(output)
 	for _, crd := range certManagerCRDs {
 		for _, line := range crdList {
 			if strings.Contains(line, crd) {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -197,7 +197,7 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -24,7 +24,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive,staticcheck
 )
 
 const (


### PR DESCRIPTION
Fixes #13. Feel free to pick one and then remove it from the list.

Remaining:

```
internal/controller/definition_controller.go:71:1: cyclomatic complexity 44 of func `(*DefinitionReconciler).Reconcile` is high (> 30) (gocyclo)
  func (r *DefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
```

```
api/v1alpha1/workspace_types.go:46:6: func initialConditionsWorkspace is unused (unused)
func initialConditionsWorkspace() []metav1.Condition {
     ^
```

```
internal/controller/definition_controller.go:465:32: func (*DefinitionReconciler).clonePodName is unused (unused)
func (r *DefinitionReconciler) clonePodName(inst *devcontainerv1alpha1.Definition) string {
```