### PR TITLE
Fix: make docker login not auto logout for ghcr

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -55,6 +55,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
+          logout: false
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
GHCR publish seems to log out and failed publish of image.

Final attempt from recommended fixes I found is to deactivate the post stage logout for the login action.