### PR TITLE
v0.0.7 release harmonize versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/everproc/devcontainer-operator:0.0.3
+IMG ?= ghcr.io/everproc/devcontainer-operator:0.0.7
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
 
@@ -159,16 +159,16 @@ undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.
 	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 build-parser:
-	$(CONTAINER_TOOL) build -f Dockerfile.parserapp . -t parserapp:0.0.1
+	$(CONTAINER_TOOL) build -f Dockerfile.parserapp . -t parserapp:0.0.7
 
 build-git-clone:
-	$(CONTAINER_TOOL) build -f Dockerfile.gitclone . -t git-clone:0.0.1
+	$(CONTAINER_TOOL) build -f Dockerfile.gitclone . -t git-clone:0.0.7
 
 build-utilities: build-parser build-git-clone
 
 build-and-push-utilities: build-utilities
-	kind load docker-image parserapp:0.0.1 parserapp:0.0.1
-	kind load docker-image git-clone:0.0.1 git-clone:0.0.1
+	kind load docker-image parserapp:0.0.7 parserapp:0.0.7
+	kind load docker-image git-clone:0.0.7 git-clone:0.0.7
 
 ##@ Dependencies
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/everproc/devcontainer-operator
-  newTag: 0.0.3
+  newTag: 0.0.7

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -8550,7 +8550,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: ghcr.io/everproc/devcontainer-operator:0.0.3
+        image: ghcr.io/everproc/devcontainer-operator:0.0.7
         livenessProbe:
           httpGet:
             path: /healthz

--- a/internal/controller/consts.go
+++ b/internal/controller/consts.go
@@ -1,4 +1,4 @@
 package controller
 
-const GIT_IMAGE_NAME = "ghcr.io/everproc/git-clone:0.0.3"
-const PARSERAPP_IMAGE_NAME = "ghcr.io/everproc/parserapp:0.0.6"
+const GIT_IMAGE_NAME = "ghcr.io/everproc/git-clone:0.0.7"
+const PARSERAPP_IMAGE_NAME = "ghcr.io/everproc/parserapp:0.0.7"


### PR DESCRIPTION
Now that the build workflow works, let's set all the versions in use to 0.0.7 and then create a release for this version to publish all images for it.